### PR TITLE
Add cancel voice button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/client/Wondermon/Wondermon/FlovatarViewController.swift
+++ b/client/Wondermon/Wondermon/FlovatarViewController.swift
@@ -412,8 +412,10 @@ class FlovatarViewController: UIViewController, UINavigationBarDelegate, SFSpeec
     @objc func audioButtonTapped(_ sender: UIButton) {
         if audioCancelButton.alpha == 0.5 {
             // Stop recording logic if button is tapped and released on the audioCancelButton
-            print("Stopped!")
-            cancelRecording()
+            if audioEngine.isRunning {
+                cancelRecording()
+                return
+            }
        }
         audioCancelButton.alpha = 1.0
 
@@ -485,13 +487,10 @@ class FlovatarViewController: UIViewController, UINavigationBarDelegate, SFSpeec
     }
     
     private func cancelRecording() {
-        print("it's a cancel!")
-        
-        audioCancelButton.isHidden = true
+        print("Voice recording cancelled")
         
         try? audioSession.setActive(false)
         audioEngine.stop()
-        recognitionRequest?.endAudio()
         audioEngine.inputNode.removeTap(onBus: 0)
 
         recognitionRequest = nil


### PR DESCRIPTION
- Add a button to cancel voice recording when tapped-> moved over -> released.

Still has a bug:
- when a voice is cancelled and we try to send a voice again, the `HOLD TO TALK` button will permanently become `RELEASE TO SEND`